### PR TITLE
Add sensiolabs insight configuration

### DIFF
--- a/.sensiolabs.yml
+++ b/.sensiolabs.yml
@@ -1,0 +1,11 @@
+php_version: 7.1
+
+php_ini: |
+  extension=redis.so
+
+rules:
+    symfony.web_config_should_not_be_present:
+        enabled: false
+
+pre_composer_script: |
+  pecl info redis || pecl install redis

--- a/.sensiolabs.yml
+++ b/.sensiolabs.yml
@@ -1,11 +1,11 @@
 php_version: 7.1
 
-php_ini: |
-  extension=redis.so
-
 rules:
     symfony.web_config_should_not_be_present:
         enabled: false
 
 pre_composer_script: |
-  pecl info redis || pecl install redis
+  yes '' | pecl install redis
+
+php_ini: |
+  extension=redis.so


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


In Sensiolabs Insight, this app should be a bootable application.
Redis needs to be installed before running composer.
With this configuration, we can add another config if needed.
https://insight.sensiolabs.com/docs